### PR TITLE
Diagnostic error when using pbart

### DIFF
--- a/R/bartDiag.R
+++ b/R/bartDiag.R
@@ -767,7 +767,7 @@ confMat <- function(model, data, response){
       geom_tile(aes(fill = Freq)) +
       scale_fill_gradient(low = "white", high = "steelblue") +
       geom_text(aes(x = response, y = pred, label = Freq)) +
-      ylab('Prediciton') +
+      ylab('Prediction') +
       xlab("Response") +
       theme_bw() +
       theme(legend.position = "none") +

--- a/R/bartDiag.R
+++ b/R/bartDiag.R
@@ -729,14 +729,18 @@ bartVimpClass <- function(model, data, combineFactors = FALSE){
 confMat <- function(model, data, response){
 
   respIdx <- which(sapply(data, identical, y = response))
-  if (inherits(model, 'bart') || inherits(model, 'pbart') || inherits(model, 'wbart')){
-    pred <-  round(colMeans(stats::predict(model, data[, -respIdx])), 0)
+  if (inherits(model, 'pbart') || inherits(model, 'wbart')){
+    pred <-  round(stats::predict(model, data[, -respIdx])$prob.test.mean, 0)
   }else{
-    pred <- round(stats::predict(model, data[, -respIdx]), 0)
+    if (inherits(model, 'bart')){
+      pred <-  round(colMeans(stats::predict(model, data[, -respIdx])), 0)
+    }else{
+      pred <- round(stats::predict(model, data[, -respIdx]), 0)
+    }
   }
 
 
-  if (inherits(model, 'pbart') || inherits(model, 'bart')){
+  if (inherits(model, 'bart')){
     pred <-  ifelse(pred == 2, 1, 0)
   }
 


### PR DESCRIPTION
Hi Alan,

Thanks for your work on this package. I wanted to try out some of these ideas on a binary outcome model and came across what I think is a bug in the `bartDiag` function when using a `pbart` model from the `BART` package. A reproducible example is below

```
## load libraries
library(BART)
library(bartMan)

set.seed(56)

## simulate data
data <- data.frame(
  y = rbinom(10, size = 1, prob = 0.5), 
  x1 = factor(rbinom(10, size = 1, prob = 0.75)), 
  x2 = rnorm(10))

## fit pbart model
model <- pbart(data[, -1], data[, 1])

## convert data set to model matrix for use in BART predictions
## (necessary when using factor covariates with BART since the
## predict function doesn't automatically generate the dummy
## variables)
data1 <- as.data.frame(bartModelMatrix(data))

## diagnostics (THIS DOESN'T WORK SINCE THE predict.pbart()
## FUNCTION DOESN'T RETURN A MATRIX AS STANDARD)
bartDiag(model = model, response = data1$y, data = data1)
AUC: 0.70833
AUCPR: 0.625
*****In main of C++ for bart prediction
tc (threadcount): 1
number of bart draws: 1000
number of trees in bart sum: 50
number of x columns: 3
from x,np,p: 3, 10
***using serial code
Error in colMeans(stats::predict(model, data[, -respIdx])) : 
  'x' must be an array of at least two dimensions
```

This happens with the latest versions of `BART` (2.9.9) and `bartMan` (0.1.2). I think the error occurs when calling the `confMat` function, since the default `predict.pbart()` method does not return a `matrix` directly. It does return an element called `prob.test.mean` that I think you can use instead. This pull request offers a possible solution (assuming my understanding of the function is correct, that you are generating a confusion matrix using a 0.5 cutoff on the predicted probabilities).

(There's also a minor typo fix on the confusion matrix plot y-axis label.)

Apologies if I've misconstrued something here.

Many thanks,

TJ